### PR TITLE
Fix Quarto YAML completion 

### DIFF
--- a/lua/cmp_r/quarto.lua
+++ b/lua/cmp_r/quarto.lua
@@ -59,6 +59,8 @@ local find_quarto_intel = function()
     return find_quarto_intel_unix(qpath2)
 end
 
+local M = {}
+
 M.get_cell_opts = function(qmd_intel)
     local qopts = {}
     local quarto_yaml_intel


### PR DESCRIPTION
I get an error when I attempt to use `cmp-r` for quarto code chunks:

```
attempt to index global 'M' (a nil value)
```

This PR  initialises it before it's first called in `quarto.lua`, same as in `chunk.lua`:

https://github.com/R-nvim/cmp-r/blob/18cecfc58f5b5a56c20b1dbb83d4a13fe982a8f7/lua/cmp_r/chunk.lua#L581-L585
